### PR TITLE
Implement pagination.

### DIFF
--- a/src/app/linux-store-angular-material/linux-store-angular-material.module.ts
+++ b/src/app/linux-store-angular-material/linux-store-angular-material.module.ts
@@ -14,6 +14,7 @@ import { MatInputModule } from '@angular/material';
 import { MatExpansionModule } from '@angular/material';
 import { MatListModule } from '@angular/material';
 import { MatTooltipModule } from '@angular/material';
+import { MatPaginatorModule } from '@angular/material/paginator';
 
 const MATERIAL_MODULES = [
   MatButtonModule,
@@ -29,7 +30,8 @@ const MATERIAL_MODULES = [
   MatToolbarModule,
   MatExpansionModule,
   MatListModule,
-  MatTooltipModule
+  MatTooltipModule,
+  MatPaginatorModule
 ];
 
 @NgModule({

--- a/src/app/pages/app-list/app-list.component.html
+++ b/src/app/pages/app-list/app-list.component.html
@@ -48,10 +48,10 @@
         <div>
           <store-app-card-list [apps]="appsToShow" [minCols]="2" [colWidth]="200" (showAppDetails)="onShowAppDetails($event)"></store-app-card-list>
         </div>
+        <mat-paginator [length]="apps ? apps.length : 0" [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 25, 50, 100]" (page)="changePage($event)">
+        </mat-paginator>
       </div>
 
     </section>
   </mat-drawer-content>
 </mat-drawer-container>
-<mat-paginator [length]="apps ? apps.length : 0" [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 25, 50, 100]" (page)="changePage($event)">
-</mat-paginator>

--- a/src/app/pages/app-list/app-list.component.html
+++ b/src/app/pages/app-list/app-list.component.html
@@ -46,10 +46,12 @@
         <h2>{{getTitle()}}</h2>
         <p *ngIf="apps">{{(apps)?.length}} results</p>
         <div>
-          <store-app-card-list [apps]="apps" [minCols]="2" [colWidth]="200" (showAppDetails)="onShowAppDetails($event)"></store-app-card-list>
+          <store-app-card-list [apps]="appsToShow" [minCols]="2" [colWidth]="200" (showAppDetails)="onShowAppDetails($event)"></store-app-card-list>
         </div>
       </div>
 
     </section>
   </mat-drawer-content>
 </mat-drawer-container>
+<mat-paginator [length]="apps ? apps.length : 0" [pageSize]="pageSize" [pageSizeOptions]="[5, 10, 25, 50, 100]" (page)="changePage($event)">
+</mat-paginator>

--- a/src/app/pages/app-list/app-list.component.ts
+++ b/src/app/pages/app-list/app-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ElementRef, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute, ParamMap, NavigationEnd } from '@angular/router';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { PageEvent } from '@angular/material/paginator';
 
 import { App } from '../../shared/app.model';
 import { Collection } from '../../shared/collection.model';
@@ -19,6 +20,7 @@ export class AppListComponent implements OnInit {
   @ViewChild('drawer') drawer;
 
   apps: App[];
+  appsToShow: App[];
   categories: Category[];
   selectedCategory: Category;
   selectedCollection: Collection;
@@ -28,6 +30,7 @@ export class AppListComponent implements OnInit {
   paramCategoryId: string;
   paramCollectionId: string;
   paramSearchKeyword: string;
+  pageSize: number = 25;
 
 
   constructor(
@@ -122,7 +125,7 @@ export class AppListComponent implements OnInit {
     this.selectedCollection = searchCollection;
 
     this.linuxStoreApiService.getAppsByKeyword(searchKeyword)
-      .subscribe(apps => { this.apps = apps; });
+      .subscribe(apps => { this.updateApps(apps); });
   }
 
   showAppsByCollectionId(collectionId: string): void {
@@ -131,12 +134,12 @@ export class AppListComponent implements OnInit {
       .subscribe(collection => { this.selectedCollection = collection; });
 
     this.linuxStoreApiService.getAppsByCollectionId(collectionId)
-      .subscribe(apps => { this.apps = apps; });
+      .subscribe(apps => { this.updateApps(apps); });
   }
 
   showAllApps(): void {
     this.linuxStoreApiService.getApps()
-      .subscribe(apps => { this.apps = apps; });
+      .subscribe(apps => { this.updateApps(apps); });
   }
 
   showAppsByCategoryId(categoryId: string): void {
@@ -145,7 +148,7 @@ export class AppListComponent implements OnInit {
       .subscribe(category => { this.selectedCategory = category; });
 
     this.linuxStoreApiService.getAppsByCategory(categoryId)
-      .subscribe(apps => { this.apps = apps; });
+      .subscribe(apps => { this.updateApps(apps); });
   }
 
   getAppsByCollectionId(collectionId: string): App[] {
@@ -173,4 +176,23 @@ export class AppListComponent implements OnInit {
     if(this.isSmallScreen()) this.drawer.close();
   }
 
+  updateApps(apps: App[]) {
+    this.apps = apps;
+    this.changePage();
+  }
+
+  changePage(pageEvent?: PageEvent) {
+    if (pageEvent) {
+      this.pageSize = pageEvent.pageSize;
+    } else {
+      pageEvent = new PageEvent();
+      pageEvent.length = this.apps.length;
+      pageEvent.pageIndex = 0;
+      pageEvent.pageSize = this.pageSize;
+    }
+    const start = pageEvent.pageIndex * pageEvent.pageSize;
+    const end = Math.min(start + pageEvent.pageSize, this.apps.length);
+    const tmpApps = this.apps.slice(start, end);
+    this.appsToShow = tmpApps;
+  }
 }


### PR DESCRIPTION
See issue #15 

This works without any changes to linux-store-backend but by doing so may download unnecessary data when user doesn't view all pages.

I've opted for 25 entries per page, but it's easy to change if chosen otherwise.