### PR TITLE
gallery: Make the background transparent

### DIFF
--- a/src/app/shared/app-details-description/app-details-description.component.ts
+++ b/src/app/shared/app-details-description/app-details-description.component.ts
@@ -19,7 +19,7 @@ export class AppDetailsDescriptionComponent implements OnInit {
     "gestures": true,
     "style": {
       "width": "100%",
-      "background": "#BCBCB6"
+      "background": "transparent"
     },
     "navigation": {},
     "loader": {


### PR DESCRIPTION
This change makes the screenshot gallery background transparent, which makes the screenshots seem more seamless with the content.

![maroon](https://user-images.githubusercontent.com/25086/39305294-8e1f2746-492a-11e8-9d68-789bcd3003f8.png)
