### PR TITLE
Switch "See More" and "App Detail Cards" to routerLink from onClick events.

### DIFF
--- a/src/app/pages/app-list/app-list.component.html
+++ b/src/app/pages/app-list/app-list.component.html
@@ -38,7 +38,7 @@
 
       <div *ngIf="showDefaultInfo && featuredCollections">
         <store-app-collection-teaser *ngFor="let collection of featuredCollections" [collectionId]="collection.id" [collectionTitle]="collection.name"
-          [collectionList]="getAppsByCollectionId(collection.id)" (showAppDetails)="onShowAppDetails($event)" (showCollection)="onShowCollection($event)">
+          [collectionList]="getAppsByCollectionId(collection.id)">
         </store-app-collection-teaser>
       </div>
 
@@ -46,7 +46,7 @@
         <h2>{{getTitle()}}</h2>
         <p *ngIf="apps">{{(apps)?.length}} results</p>
         <div>
-          <store-app-card-list [apps]="apps" [minCols]="2" [colWidth]="200" (showAppDetails)="onShowAppDetails($event)"></store-app-card-list>
+          <store-app-card-list [apps]="apps" [minCols]="2" [colWidth]="200"></store-app-card-list>
         </div>
       </div>
 

--- a/src/app/pages/app-list/app-list.component.ts
+++ b/src/app/pages/app-list/app-list.component.ts
@@ -187,14 +187,6 @@ export class AppListComponent implements OnInit {
     this.showAppsByParams();
   }
 
-  onShowAppDetails(app: App) {
-    this.router.navigate(['apps/details', app.flatpakAppId]);
-  }
-
-  onShowCollection(collectionId: string) {
-    this.router.navigate(['apps/collection', collectionId]);
-  }
-
   onDrawerLinkClick() {
     if (this.isSmallScreen()) {
       this.drawer.close();

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -10,7 +10,7 @@
       </p>
       <div>
         <a mat-raised-button color="primary" href="https://flatpak.org/setup">Quick setup</a>
-        <button mat-raised-button color="primary" routerLink="/apps">Browse the apps</button>
+        <a mat-raised-button color="primary" routerLink="/apps">Browse the apps</a>
       </div>
     </div>
   </header>
@@ -19,7 +19,7 @@
   <section fxFlex class="store-content-container">
     <div *ngIf="featuredCollections">
       <store-app-collection-teaser *ngFor="let collection of featuredCollections" [collectionId]="collection.id" [collectionTitle]="collection.name"
-        [collectionList]="getAppsByCollectionId(collection.id)" (showAppDetails)="onShowAppDetails($event)" (showCollection)="onShowCollection($event)">
+        [collectionList]="getAppsByCollectionId(collection.id)">
       </store-app-collection-teaser>
     </div>
   </section>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -43,14 +43,6 @@ export class HomeComponent implements OnInit {
     return collectionApps;
   }
 
-  onShowAppDetails(app: App) {
-    this.router.navigate(['apps/details', app.flatpakAppId]);
-  }
-
-  onShowCollection(collectionId: string) {
-    this.router.navigate(['apps/collection', collectionId]);
-  }
-
   setPageMetadata() {
     const imageUrl: string = window.location.protocol + '//' + window.location.hostname + ':' +
       window.location.port + '/assets/themes/flathub/flathub-screenshot.png'

--- a/src/app/shared/app-card-list/app-card-list.component.html
+++ b/src/app/shared/app-card-list/app-card-list.component.html
@@ -1,6 +1,5 @@
 <mat-grid-list #applist cols="{{calculatedNumCols}}" gutterSize="12" rowHeight="6:7" (window:resize)="onResize($event)">
-  <a *ngFor="let app of appsToShow" href="/apps/details/{{app.flatpakAppId}}"
-        (click)="onAppDetails(app); $event.preventDefault()">
+  <a *ngFor="let app of appsToShow" [routerLink]="['/apps','details', app.flatpakAppId]">
     <mat-grid-tile>
       <mat-icon class="badge" *ngIf="showNewBadge(app)" color="primary" matTooltip="New!" matTooltipPosition="left">
         new_releases

--- a/src/app/shared/app-card-list/app-card-list.component.ts
+++ b/src/app/shared/app-card-list/app-card-list.component.ts
@@ -31,9 +31,6 @@ export class AppCardListComponent implements OnInit, OnChanges {
   appsToShow: App[];
   calculatedNumCols: number;
 
-  @Output('showAppDetails')
-  showAppDetails: EventEmitter<App> = new EventEmitter<App>();
-
   ngOnInit() {
     // console.log("AppCardList onInit");
     if (!this.minCols) {
@@ -54,10 +51,6 @@ export class AppCardListComponent implements OnInit, OnChanges {
     // console.log("AppCardList onResize");
     this.updateNumCols();
     this.updateAppsToShow();
-  }
-
-  onAppDetails(app: App): void {
-    this.showAppDetails.emit(app);
   }
 
   updateNumCols() {

--- a/src/app/shared/app-collection-teaser/app-collection-teaser.component.html
+++ b/src/app/shared/app-collection-teaser/app-collection-teaser.component.html
@@ -1,8 +1,8 @@
 <div fxLayout="row" fxLayoutAlign="start baseline">
   <h2 fxFlex>{{collectionTitle}}</h2>
-  <button mat-raised-button color="primary" (click)="onSeeMore()">See more</button>
+  <a [routerLink]="['/apps', 'collection', collectionId]" mat-raised-button color="primary" >See more</a>
 </div>
 <div>
   <store-app-card-list [apps]="collectionList" [rows]="1"
-   [minCols]="2" [colWidth]="200" (showAppDetails)="onShowAppDetails($event)"></store-app-card-list>
+   [minCols]="2" [colWidth]="200"></store-app-card-list>
 </div>

--- a/src/app/shared/app-collection-teaser/app-collection-teaser.component.ts
+++ b/src/app/shared/app-collection-teaser/app-collection-teaser.component.ts
@@ -12,19 +12,4 @@ export class AppCollectionTeaserComponent {
   @Input() collectionId: string;
   @Input() collectionTitle: string;
   @Input() collectionList: App[];
-
-  @Output('showAppDetails')
-  showAppDetails: EventEmitter<App> = new EventEmitter<App>();
-
-  @Output('showCollection')
-  showCollection: EventEmitter<string> = new EventEmitter<string>();
-
-  onShowAppDetails(app: App): void {
-    this.showAppDetails.emit(app);
-  }
-
-  onSeeMore(): void {
-    this.showCollection.emit(this.collectionId);
-  }
-
 }

--- a/src/app/shared/toolbar/toolbar.component.html
+++ b/src/app/shared/toolbar/toolbar.component.html
@@ -36,14 +36,14 @@
 
     <mat-menu #menu="matMenu">
 
-      <button mat-menu-item routerLink="apps">
+      <a mat-menu-item routerLink="apps">
         <span>APPLICATIONS</span>
-      </button>
+      </a>
       <a mat-menu-item href="https://github.com/flathub/flathub/wiki/App-Submission" aria-label="Publish your app on Flathub">PUBLISH
       </a>
-      <button mat-menu-item routerLink="about">
+      <a mat-menu-item routerLink="about">
         <span>ABOUT</span>
-      </button>
+      </a>
 
     </mat-menu>
 


### PR DESCRIPTION
I noticed that you couldn't open app detail cards or the "see more" button in a new tab. 
The main reason seemed to be that these were routed using custom events rather than Angular's routerLink. 
Switching to routerLink allows Angular to apply the correct semantic markup for the browser (and any assistive technologies) to correctly interact with the link. 

Let me know if you want me to make any changes or submit the pull request in a different manner.

Thanks!