### PR TITLE
Improve readability of app descriptions

### DIFF
--- a/src/app/shared/app-details-description/app-details-description.component.scss
+++ b/src/app/shared/app-details-description/app-details-description.component.scss
@@ -10,8 +10,7 @@ gallery {
 }
 
 .app-details-description {
-  font-size: 14px;
-  line-height: 1.4;
-  text-align: justify;
-  text-justify: inter-word;
+  font-size: 16px;
+  line-height: 1.35;
+  color: #24292e;
 }


### PR DESCRIPTION
I made this change quite some time ago, I thought I’d work on it more but never actually found the time to do so, but I’m posting it here to get the discussion going at least because I think the typography on flathub.org is _tiny_, which makes it look quite bad on low-resolution displays.

From the commit message:

> This should hopefully make the descriptions more attractive to read.
>
> Enlarge the point size a bit and slightly turn down the contrast (colour borrowed from GitHub, cheers) to make it a bit more pleasant to read. Also turn off justifying, since we don’t have hyphenation, to prevent the text from getting too spaced out at times, and shrink the leading a wee bit to give it a more cohesive feel.