### PR TITLE
Redirect to not found page, when no app is found.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { BadgesComponent } from './pages/badges/badges.component';
 import { CodeOfConductComponent } from './pages/code-of-conduct/code-of-conduct.component';
 import { AppListComponent } from './pages/app-list/app-list.component';
 import { AppDetailsComponent } from './pages/app-details/app-details.component';
+import { NotFoundComponent } from './pages/not-found/not-found.component';
 
 const appRoutes: Routes = [
   {
@@ -59,6 +60,10 @@ const appRoutes: Routes = [
   {
     path: 'apps/details/:appId',
     component: AppDetailsComponent
+  },
+  {
+    path: 'not-found',
+    component: NotFoundComponent
   },
   {
     path: '',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,6 +41,7 @@ import { CodeOfConductComponent } from './pages/code-of-conduct/code-of-conduct.
 import { PreComponent } from './shared/pre/pre.component';
 import { BadgesComponent } from './pages/badges/badges.component';
 import { FeedsComponent } from './pages/feeds/feeds.component';
+import { NotFoundComponent } from './pages/not-found/not-found.component';
 
 
 @NgModule({
@@ -66,7 +67,8 @@ import { FeedsComponent } from './pages/feeds/feeds.component';
     CodeOfConductComponent,
     PreComponent,
     BadgesComponent,
-    FeedsComponent
+    FeedsComponent,
+    NotFoundComponent,
   ],
   entryComponents: [
     AppDetailsExtraInfoLicenseModalComponent

--- a/src/app/pages/app-details/app-details.component.ts
+++ b/src/app/pages/app-details/app-details.component.ts
@@ -95,7 +95,14 @@ export class AppDetailsComponent implements OnInit {
 
   getApp(id: string): void {
     this.linuxStoreApiService.getApp(id)
-      .subscribe(app => { this.app = app; this.setPageMetadata(); });
+      .subscribe(app => {
+        this.app = app;
+        if (!app) {
+          this.router.navigate(['/not-found'])
+        } else {
+          this.setPageMetadata();
+        }
+      });
   }
 
   getReviews(id: string): void {

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,0 +1,17 @@
+<div class="not-found">
+  <h1>
+    It would be regular 404 page
+  </h1>
+  <h3>
+    ...except, we don't receive
+    <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"
+      >404</a
+    >
+    response status!
+  </h3>
+  <p>Go back to <a routerLink="/home">Homepage</a>,</p>
+  <p>
+    or consider making Flathub better, by contributing to our
+    <a href="https://github.com/flathub/">open source services</a>.
+  </p>
+</div>

--- a/src/app/pages/not-found/not-found.component.scss
+++ b/src/app/pages/not-found/not-found.component.scss
@@ -1,0 +1,4 @@
+.not-found {
+  min-height: 65vh;
+  padding: 0 5%;
+}

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -1,0 +1,9 @@
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "not-found",
+  templateUrl: "./not-found.component.html",
+  styleUrls: ['./not-found.component.scss']
+})
+
+export class NotFoundComponent {}


### PR DESCRIPTION
Description of problem, that is solved in this PR is in #187 .

In few words, last part of url in app details `https://www.flathub.org/apps/details/org.inkscape.Inkscape` is parameter, that is taken to request for app details data. If it is not found on backend side, 200 OK is returned with empty response body. That resulted with empty white page, that is unfriendly.
<img width="2531" alt="Screenshot 2020-02-20 at 08 48 45" src="https://user-images.githubusercontent.com/23322970/74912104-45503f00-53be-11ea-9a98-c3f0044119b2.png">

If you have better idea for not-found page, feel free to suggest it in comments, I just don't wanted it to be dry, casual 404 page ;)