### PR TITLE
Style: add generated shadows to app icons

### DIFF
--- a/src/app/shared/app-card-list/app-card-list.component.scss
+++ b/src/app/shared/app-card-list/app-card-list.component.scss
@@ -2,6 +2,7 @@
   margin-left: auto;
   margin-right: auto;
   min-height: 6em;
+  filter: drop-shadow(0 0.08rem 0.1rem rgba(0,0,0, 0.25)) drop-shadow(0 0.4rem 0.7rem rgba(0,0,0, 0.14));
 
   img {
     width: 64px;


### PR DESCRIPTION
This adds a subtle shadow to icons, to improve the legibility of light icons (e.g. Boxes) on light backgrounds. We do the same thing in Software, Settings, and other places app icons are displayed.

![image](https://user-images.githubusercontent.com/1908896/81171271-69bebf00-8f9c-11ea-8a14-ccff6226de7f.png)
