### PR TITLE
autofocus search on pageload

### DIFF
--- a/src/app/shared/toolbar/toolbar.component.html
+++ b/src/app/shared/toolbar/toolbar.component.html
@@ -11,7 +11,7 @@
         <div [class]="'search-form '+(showSearchInput? 'active': '')">
           <mat-icon class="search-box-icon show-md" (click)="onTogleSearch()">arrow_back</mat-icon>
           <mat-icon class="search-box-icon hide-md" (click)="onSearch(searchBox.value)">search</mat-icon>
-          <input #searchBox id="search-box" class="search-box" type="search" placeholder="Search apps" (keyup.enter)="onSearch(searchBox.value)" />
+          <input #searchBox id="search-box" class="search-box" type="search" placeholder="Search apps" (keyup.enter)="onSearch(searchBox.value)" autofocus />
         </div>
       </div>
     </div>


### PR DESCRIPTION
HTML5 `autofocus` attribute on search text field; (partly?) fixes #192