### PR TITLE
Add seoService to not-found component

### DIFF
--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -1,8 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { SeoService } from '../../seo.service';
 
 @Component({
   selector: 'not-found',
   templateUrl: './not-found.component.html',
   styleUrls: ['./not-found.component.scss'],
 })
-export class NotFoundComponent {}
+
+export class NotFoundComponent implements OnInit {
+  constructor(
+    private seoService: SeoService
+  ) {}
+
+  setPageMetadata() {
+    this.seoService.setPageMetadata(
+        '404 - Page not found',
+        'Page not found',
+        '',
+        '404'
+    );
+  }
+
+  ngOnInit() {
+    this.setPageMetadata();
+  }
+}


### PR DESCRIPTION
It is needed to provide 404 meta tag for
prerenderer to avoid cache-ing that page.

It is continuation of #274 
cc @barthalion 