### PR TITLE
Fix searching on iOS

### DIFF
--- a/src/app/shared/toolbar/toolbar.component.html
+++ b/src/app/shared/toolbar/toolbar.component.html
@@ -11,7 +11,7 @@
         <div [class]="'search-form '+(showSearchInput? 'active': '')">
           <mat-icon class="search-box-icon show-md" (click)="onTogleSearch()">arrow_back</mat-icon>
           <mat-icon class="search-box-icon hide-md" (click)="onSearch(searchBox.value)">search</mat-icon>
-          <input #searchBox id="search-box" class="search-box" type="search" placeholder="Search apps" (keyup.enter)="onSearch(searchBox.value)" autofocus />
+          <input #searchBox id="search-box" class="search-box" type="search" placeholder="Search apps" (keyup.enter)="onSearch(searchBox.value)" autofocus autocapitalize="none"/>
         </div>
       </div>
     </div>


### PR DESCRIPTION
From issue #266

It's caused by the keyboard attempting to capitalize the Enter key (referenced from angular/angular#32963)

This just applies the workaround suggested in the comments (https://github.com/angular/angular/issues/32963#issuecomment-543712884). Autocapitalization in the search bar will be turned off so that the keyboard on iOS won't send "Shift+Enter" instead of just "Enter"
